### PR TITLE
ansi C allows `.` and `_` to start a file name

### DIFF
--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -337,7 +337,7 @@ sub test_name_portability {
 
 # check if the name only uses portable filename characters, as defined by ANSI C
     if ( $tests{ansi_chars} ) {
-        /^[A-Za-z0-9][A-Za-z0-9._-]*$/ or $bad_names{$file} .= 'ansi_chars,';
+        /^[A-Za-z0-9._][A-Za-z0-9._-]*$/ or $bad_names{$file} .= 'ansi_chars,';
     }
 
     # check if the name contains more than one dot


### PR DESCRIPTION
Update the ANSI C filename portability checker to match the semantics
as stated in perlport. Fixes #1.
