### PR TITLE
update the ansi_chars check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.build/
+!/.gitignore
+/Test-Portability-Files-*/
+/Test-Portability-Files-*.tar.gz

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+Revision history for {{ $dist->name }}
+
 {{ $NEXT }}
         - relax the ansi_chars check to allow for . and _ as the leading
           character of a filename

--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{ $NEXT }}
+        - relax the ansi_chars check to allow for . and _ as the leading
+          character of a filename
 
 0.06      2012-11-12 19:24:46 Europe/Vienna
         - created git repository on github.com

--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -337,7 +337,7 @@ sub test_name_portability {
 
 # check if the name only uses portable filename characters, as defined by ANSI C
     if ( $tests{ansi_chars} ) {
-        /^[A-Za-z0-9][A-Za-z0-9._-]*$/ or $bad_names{$file} .= 'ansi_chars,';
+        /^[A-Za-z0-9._][A-Za-z0-9._-]*$/ or $bad_names{$file} .= 'ansi_chars,';
     }
 
     # check if the name contains more than one dot


### PR DESCRIPTION
perlport.pod's discussion of ANSI characters in filenames allows for . and _ to be used as the first character -- only "-" should be disallowed.
