### PR TITLE
Add a prereq for the minimum perl version.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,6 +23,7 @@ repository.web = https://github.com/abraxxa/Test-Portability-Files
 
 
 [Prereqs]
+perl = 5.600
 File::Basename = 0
 File::Find = 0
 File::Spec = 0


### PR DESCRIPTION
This pull request is part of the CPAN Pull Request Challenge 2016 and adds a minimum Perl version to dist.ini based on `perlver`'s output:

```
monsieurp@epsilon ~/git_projects/Test-Portability-Files $ perlver .


   ------------------------------------------------------------  
 | file                          | explicit | syntax | external |
 | ------------------------------------------------------------ |
 | lib/Test/Portability/Files.pm | ~        | v5.6.0 | n/a      |
 | t/01basic.t                   | ~        | ~      | n/a      |
 | t/portfs.t                    | ~        | ~      | n/a      |
 | ------------------------------------------------------------ |
 | Minimum explicit version : ~                                 |
 | Minimum syntax version   : v5.6.0                            |
 | Minimum version of perl  : v5.6.0                            |
   ------------------------------------------------------------  
```

This warning shows up in CPANTS for this package: http://cpants.cpanauthors.org/kwalitee/meta_yml_declares_perl_version
