### PR TITLE
fix regex for windows reserved files

### DIFF
--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -347,7 +347,7 @@ sub test_name_portability {
 
     # check if the name is a Windows Reserved Filename
     if ( $tests{'windows_reserved'} ) {
-      /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])[.]?/i and $bad_names{$file} .= 'windows_reserved,';
+        $file_name =~ /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i and $bad_names{$file} .= 'windows_reserved,';
     }
 
     # check if the name contains more than one dot


### PR DESCRIPTION
The reserved file names should only be blocked if they are the entire
file name, or the portion of the file name without the extension.