### PR TITLE
Fix leftover bits from the windows_reserved tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
         - update POD about windows reserved file tests
+        - add tests for windows reserved file tests
 
 0.09      2017-12-31 11:30:04+01:00 Europe/Vienna
         - fix regex for windows reserved files (RT#123972)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+        - update POD about windows reserved file tests
 
 0.09      2017-12-31 11:30:04+01:00 Europe/Vienna
         - fix regex for windows reserved files (RT#123972)

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for {{ $dist->name }}
 {{ $NEXT }}
         - update POD about windows reserved file tests
         - add tests for windows reserved file tests
+        - fix bug with windows reserved file tests so that files like "con.dat.txt" will fail
 
 0.09      2017-12-31 11:30:04+01:00 Europe/Vienna
         - fix regex for windows reserved files (RT#123972)

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for {{ $dist->name }}
         - update POD about windows reserved file tests
         - add tests for windows reserved file tests
         - fix bug with windows reserved file tests so that files like "con.dat.txt" will fail
+        - add missing error text for windows reserved tests
 
 0.09      2017-12-31 11:30:04+01:00 Europe/Vienna
         - fix regex for windows reserved files (RT#123972)

--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -171,7 +171,7 @@ C<test_vms_length> is enabled
 
 =item *
 
-C<windows_reserved> is enabled
+C<test_windows_reserved> is enabled
 
 =back
 
@@ -273,6 +273,10 @@ C<test_symlink> - check that the file is not a symbolic link.
 
 C<test_vms_length> - check that the name fits within VMS name length limitations
 (39 characters max for the base name, 39 characters max for the extension).
+
+C<test_windows_reserved> - check that the file name is not one of the
+reserved Windows filenames that correspond to character devices, such
+as F<con> or F<com1>.
 
 =back
 

--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -351,7 +351,7 @@ sub test_name_portability {
 
     # check if the name is a Windows Reserved Filename
     if ( $tests{'windows_reserved'} ) {
-        $file_name =~ /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i
+        $file_name =~ /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)*$/i
             and $bad_names{$file} .= 'windows_reserved,';
     }
 

--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -85,6 +85,10 @@ my %errors_text =
     case => "The name of these files differ only by the case, which can\n"
         . "cause real problems on case-insensitive filesystems:",
 
+    windows_reserved =>
+        "These files have names that correspond to reserved character devices\n"
+         . "on Windows, and can cause unexpected problems:",
+
     'symlink' => "The following files are symbolic links, which are not\n"
         . "supported on several operating systems:",
     );

--- a/t/02filenames.t
+++ b/t/02filenames.t
@@ -32,6 +32,9 @@ expect_error('/home/user/dos_eight.txtx', 'dos_length');
 
 expect_error('/home/user/con', 'windows_reserved');
 expect_error('/home/user/com1.txt', 'windows_reserved');
+expect_error('/home/user/prn.dat.zip', 'windows_reserved');
+
+expect_error('/home/user/CONTRIB', undef);
 
 # symlink and dir_noext tests actually use the file system, so they can only
 # be tested on certain systems

--- a/t/02filenames.t
+++ b/t/02filenames.t
@@ -30,6 +30,9 @@ expect_error('/home/user/foo.thirty_nine_is_the_limit_for_files_onVMS', 'vms_len
 expect_error('/home/user/dos_eight.txt', 'dos_length');
 expect_error('/home/user/dos_eight.txtx', 'dos_length');
 
+expect_error('/home/user/con', 'windows_reserved');
+expect_error('/home/user/com1.txt', 'windows_reserved');
+
 # symlink and dir_noext tests actually use the file system, so they can only
 # be tested on certain systems
 my $tempdir;


### PR DESCRIPTION
- Fix the regex, so that it will actually catch files like "con.dat.txt" but not "contributing"
- Add tests for windows reserved files and a check that "CONTRIB" won't fail
- Add missing error text
- Add POD
