### PR TITLE
Add Pod::Weaver configuration to build BUGS and CONTRIBUTOR sections

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+        - Add Pod::Weaver configuration
 
 0.09      2017-12-31 11:30:04+01:00 Europe/Vienna
         - fix regex for windows reserved files (RT#123972)

--- a/dist.ini
+++ b/dist.ini
@@ -20,6 +20,11 @@ critic_config = t/perlcriticrc
 repository.type = git
 repository.url = https://github.com/abraxxa/Test-Portability-Files.git
 repository.web = https://github.com/abraxxa/Test-Portability-Files
+bugtracker.web    = https://rt.cpan.org/Dist/Display.html?Queue=Test-Portability-Files
+bugtracker.mailto = bug-test-portability-files@rt.cpan.org
+
+[Git::Contributors]
+:version = 0.019
 
 [@Git]
 commit_msg  = version %v%n%n%c

--- a/lib/Test/Portability/Files.pm
+++ b/lib/Test/Portability/Files.pm
@@ -472,13 +472,6 @@ sub _bad_names {
 
 L<perlport>
 
-=head1 BUGS
-
-Please report any bugs or feature requests to
-C<bug-test-portability-files@rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org>.  I will be notified, and then you'll automatically
-be notified of progress on your bug as I make changes.
-
 =cut
 
 1;

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,0 +1,23 @@
+[@CorePrep]
+
+[Name]
+
+[Version]
+
+[Region  / prelude]
+
+[Generic / SYNOPSIS]
+[Generic / DESCRIPTION]
+
+[Leftovers]
+
+[Region  / postlude]
+
+[SourceGitHub]
+[Bugs]
+
+[Authors]
+
+[Contributors]
+
+[Legal]


### PR DESCRIPTION
This change adds a Pod::Weaver configuration file so that the BUGS and CONTRIBUTOR sections are built.  The contributors will be retrieved from the Git history.

As a side-benefit, the bug tracker and contributor information will be added to the module metadata.